### PR TITLE
#155: fix bug with github username query

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,10 +18,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-# @todo #153:1h Hey, take a look at test_source.rb:192. I don't know
-#  what to do there. The test is supposed to work, but it doesn't.
-#  Please, investigate and it.
-
 require 'rubygems'
 require 'rake'
 require 'rdoc'

--- a/lib/pdd/source.rb
+++ b/lib/pdd/source.rb
@@ -205,13 +205,11 @@ at position ##{prefix.length + 1}."
 
     def find_github_user(info)
       email, author = info.values_at(:email, :author)
-
       # if email is not defined, changes have not been committed
       return if email.nil?
       base_uri = 'https://api.github.com/search/users?per_page=1'
       query = base_uri + "&q=#{email}+in:email"
       json = get_json query
-
       # find user by name instead since users can make github email private
       unless json['total_count'].positive?
         return if author.nil?

--- a/lib/pdd/source.rb
+++ b/lib/pdd/source.rb
@@ -208,7 +208,6 @@ at position ##{prefix.length + 1}."
 
       # if email is not defined, changes have not been committed
       return if email.nil?
-
       base_uri = 'https://api.github.com/search/users?per_page=1'
       query = base_uri + "&q=#{email}+in:email"
       json = get_json query
@@ -216,11 +215,9 @@ at position ##{prefix.length + 1}."
       # find user by name instead since users can make github email private
       unless json['total_count'].positive?
         return if author.nil?
-
         query = base_uri + "&q=#{author}+in:fullname"
         json = get_json query
       end
-
       json['items'].first
     end
 

--- a/test/test_source.rb
+++ b/test/test_source.rb
@@ -153,7 +153,7 @@ class TestSource < Minitest::Test
         cd '#{dir}'
         git init --quiet .
         git config user.email test@teamed.io
-        git config user.name test
+        git config user.name test_unknown
         echo '\x40todo #1 this is the puzzle' > a.txt
         git add a.txt
         git commit --quiet -am 'first version'
@@ -164,7 +164,7 @@ class TestSource < Minitest::Test
       assert_equal '1-de87adc8', puzzle.props[:id]
       assert_equal '1-1', puzzle.props[:lines]
       assert_equal 'this is the puzzle', puzzle.props[:body]
-      assert_equal 'test', puzzle.props[:author]
+      assert_equal 'test_unknown', puzzle.props[:author]
       assert_equal 'test@teamed.io', puzzle.props[:email]
       assert_match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/, puzzle.props[:time])
     end
@@ -189,7 +189,7 @@ class TestSource < Minitest::Test
       assert_equal '1-de87adc8', puzzle.props[:id]
       assert_equal '1-1', puzzle.props[:lines]
       assert_equal 'this is the puzzle', puzzle.props[:body]
-      # assert_equal 'test', puzzle.props[:author]
+      assert_equal 'test', puzzle.props[:author]
       assert_nil puzzle.props[:email]
       assert_match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/, puzzle.props[:time])
     end
@@ -211,6 +211,27 @@ class TestSource < Minitest::Test
       assert_equal 1, list.size
       puzzle = list.first
       assert_equal '@yegor256', puzzle.props[:author]
+    end
+  end
+
+  def test_skips_uncommitted_changes
+    skip if Gem.win_platform?
+    Dir.mktmpdir 'test' do |dir|
+      raise unless system("
+        cd '#{dir}'
+        git init --quiet .
+        git config user.email yegor256@gmail.com
+        git config user.name test
+        echo 'hi' > a.txt
+        git add a.txt
+        git commit --quiet -am 'first version'
+        echo '\x40todo #1 this is a puzzle uncommitted' > a.txt
+      ")
+      list = PDD::Source.new(File.join(dir, 'a.txt'), '').puzzles
+      assert_equal 1, list.size
+      puzzle = list.first
+      assert_nil puzzle.props[:email]
+      assert_equal 'Not Committed Yet', puzzle.props[:author]
     end
   end
 


### PR DESCRIPTION
The issue fixed here is due to the following facts:
1. that empty queries to get a user from github API returns all users with Linus Torvalds as the first user in the list.
2. some users have their github email as private (see screenshot), therefore their data can't be queried with the email. The fallback is to query with the user's fullname provided that is also defined.

Screenshot:
<img width="480" alt="Screenshot 2021-07-03 at 15 34 48" src="https://user-images.githubusercontent.com/10655408/124361790-cfeab480-dc28-11eb-83ca-a21af5753936.png">

