### PR TITLE
#96: allow markers on contiguous lines

### DIFF
--- a/test/test__helper.rb
+++ b/test/test__helper.rb
@@ -29,3 +29,16 @@ end
 
 require 'minitest/autorun'
 require_relative '../lib/pdd'
+
+def stub_source_find_github_user(file, path = '')
+  source = PDD::Source.new(file, path)
+  verbose_source = PDD::VerboseSource.new(file, source)
+  fake = proc do |info = {}|
+    email, author = info.values_at(:email, :author)
+    { 'login' => 'yegor256' } if email == 'yegor256@gmail.com' ||
+                                 author == 'Yegor Bugayenko'
+  end
+  source.stub :find_github_user, fake do
+    yield verbose_source
+  end
+end

--- a/test/test_source_todo.rb
+++ b/test/test_source_todo.rb
@@ -24,12 +24,12 @@ require_relative '../lib/pdd'
 require_relative '../lib/pdd/sources'
 
 class TestSourceTodo < Minitest::Test
-  def check_valid_puzzle(text, lines, body, ticket)
+  def check_valid_puzzle(text, lines, body, ticket, count = 1)
     Dir.mktmpdir 'test' do |dir|
       file = File.join(dir, 'a.txt')
       File.write(file, text)
       list = PDD::VerboseSource.new(file, PDD::Source.new(file, 'hey')).puzzles
-      assert_equal 1, list.size
+      assert_equal count, list.size
       puzzle = list.first
       assert_equal lines, puzzle.props[:lines]
       assert_equal body, puzzle.props[:body]
@@ -79,6 +79,19 @@ class TestSourceTodo < Minitest::Test
       '2-2',
       'task description',
       '45'
+    )
+  end
+
+  def test_multiple_todo_colon
+    check_valid_puzzle(
+      "
+      // TODO: #45 task description
+      // TODO: #46 another task description
+      ",
+      '2-2',
+      'task description',
+      '45',
+      2
     )
   end
 

--- a/test/test_source_todo.rb
+++ b/test/test_source_todo.rb
@@ -28,12 +28,14 @@ class TestSourceTodo < Minitest::Test
     Dir.mktmpdir 'test' do |dir|
       file = File.join(dir, 'a.txt')
       File.write(file, text)
-      list = PDD::VerboseSource.new(file, PDD::Source.new(file, 'hey')).puzzles
-      assert_equal count, list.size
-      puzzle = list.first
-      assert_equal lines, puzzle.props[:lines]
-      assert_equal body, puzzle.props[:body]
-      assert_equal ticket, puzzle.props[:ticket]
+      stub_source_find_github_user(file, 'hey') do |source|
+        list = source.puzzles
+        assert_equal count, list.size
+        puzzle = list.first
+        assert_equal lines, puzzle.props[:lines]
+        assert_equal body, puzzle.props[:body]
+        assert_equal ticket, puzzle.props[:ticket]
+      end
     end
   end
 
@@ -42,7 +44,7 @@ class TestSourceTodo < Minitest::Test
       file = File.join(dir, 'a.txt')
       File.write(file, text)
       error = assert_raises PDD::Error do
-        PDD::VerboseSource.new(file, PDD::Source.new(file, 'hey')).puzzles
+        stub_source_find_github_user(file, 'hey', &:puzzles)
       end
       assert !error.message.index(error_msg).nil?
     end


### PR DESCRIPTION
Parses these markers correctly ✅ 
```
# TODO: #85 Make custom callbacks
# TODO: #85 Check alert messages
# TODO: #85 Refactor methods

// @todo: #85 Another marker
// @todo: #85 Yet another marker
```

Resolves #96 