### PR TITLE
#165: format error/warn message with file link

### DIFF
--- a/features/catches_broken_puzzles.feature
+++ b/features/catches_broken_puzzles.feature
@@ -21,7 +21,7 @@ Feature: Catches Broken Puzzles
     }
     """
     When I run pdd it fails with "Space expected"
-    When I run pdd it fails with "puzzle at line #6"
+    When I run pdd it fails with "Sample.java:6"
 
   Scenario: Throwing exception on yet another broken puzzle
     Given I have a "Sample.java" file with content:

--- a/lib/pdd/source.rb
+++ b/lib/pdd/source.rb
@@ -38,7 +38,7 @@ module PDD
 
     # Fetch all puzzles.
     def puzzles
-      PDD.log.info "Reading #{@path}..."
+      PDD.log.info "Reading #{@path} ..."
       puzzles = []
       lines = File.readlines(@file, encoding: 'UTF-8')
       lines.each_with_index do |line, idx|
@@ -50,7 +50,7 @@ module PDD
             end
           end
         rescue Error, ArgumentError => ex
-          message = "puzzle at line ##{idx + 1}; #{ex.message}"
+          message = "#{@path}:#{idx + 1} puzzle at line ##{idx + 1}; #{ex.message}"
           raise Error, message unless PDD.opts && PDD.opts['skip-errors']
           PDD.log.warn message
         end

--- a/lib/pdd/source.rb
+++ b/lib/pdd/source.rb
@@ -50,7 +50,7 @@ module PDD
             end
           end
         rescue Error, ArgumentError => ex
-          message = "#{@path}:#{idx + 1} puzzle at line ##{idx + 1}; #{ex.message}"
+          message = "#{@path}:#{idx + 1} #{ex.message}"
           raise Error, message unless PDD.opts && PDD.opts['skip-errors']
           PDD.log.warn message
         end


### PR DESCRIPTION
Fixed as shown in image;

<img width="731" alt="Screenshot 2021-07-13 at 15 13 25" src="https://user-images.githubusercontent.com/10655408/125467467-eac95052-0070-4604-af07-cb922382a1c1.png">
