### PR TITLE
[#113] use pessimistic version constraint

### DIFF
--- a/pdd.gemspec
+++ b/pdd.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
     s.required_rubygems_version = Gem::Requirement.new('>= 0')
   end
   s.rubygems_version = '2.3'
-  s.required_ruby_version = '>= 2.3'
+  s.required_ruby_version = '~> 2.3'
   s.name = 'pdd'
   s.version = PDD::VERSION
   s.license = 'MIT'


### PR DESCRIPTION
## Description

Use pessimistic update ~> 2.3. 
Note: Ruby 2.3 is EOL. And it will be good to have a new version like ~2.7.

## Types of changes

- [ ] Documentation Update 📝
- [x] Build/Workflow Update 👷
- [ ] Other (please describe)

## Checklist

- [x] Lint and tests pass locally with my changes
- [ ] Added documentation (if appropriate)

