### PR TITLE
[#164] save puzzle content as utf-8

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ The XML produced will look approximately like this (here is a
   </puzzle>
 </puzzles>
 ```
+NOTE: puzzles are saved with utf-8 encoding
 
 [XSD Schema](http://pdd-xsd.teamed.io/0.19.4.xsd) is here.
 The most interesting parts of each puzzle are:

--- a/lib/pdd.rb
+++ b/lib/pdd.rb
@@ -97,7 +97,7 @@ module PDD
       end
       sanitize(
         rules(
-          Nokogiri::XML::Builder.new(:encoding => 'UTF-8') do |xml|
+          Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |xml|
             xml << "<?xml-stylesheet type='text/xsl' href='#{xsl}'?>"
             xml.puzzles(attrs) do
               sources.fetch.each do |source|

--- a/lib/pdd.rb
+++ b/lib/pdd.rb
@@ -97,7 +97,7 @@ module PDD
       end
       sanitize(
         rules(
-          Nokogiri::XML::Builder.new do |xml|
+          Nokogiri::XML::Builder.new(:encoding => 'UTF-8') do |xml|
             xml << "<?xml-stylesheet type='text/xsl' href='#{xsl}'?>"
             xml.puzzles(attrs) do
               sources.fetch.each do |source|

--- a/test/test_source.rb
+++ b/test/test_source.rb
@@ -116,6 +116,25 @@ class TestSource < Minitest::Test
     end
   end
 
+  def test_succeed_utf8_encoded_body
+    Dir.mktmpdir 'test' do |dir|
+      file = File.join(dir, 'a.txt')
+      File.write(
+        file,
+        "
+        * \x40todo #44 Привет, мир, мне кофе
+        *  вторая линия
+        "
+      )
+      list = PDD::VerboseSource.new(file, PDD::Source.new(file, 'hey')).puzzles
+      assert_equal 1, list.size
+      puzzle = list.first
+      assert_equal '2-3', puzzle.props[:lines]
+      assert_equal 'Привет, мир, мне кофе вторая линия', puzzle.props[:body]
+      assert_equal '44', puzzle.props[:ticket]
+    end
+  end
+
   def test_failing_on_incomplete_puzzle
     Dir.mktmpdir 't5' do |dir|
       file = File.join(dir, 'ff.txt')

--- a/test/test_source_todo.rb
+++ b/test/test_source_todo.rb
@@ -71,6 +71,18 @@ class TestSourceTodo < Minitest::Test
     )
   end
 
+  def test_todo_utf8_encoded_body
+    check_valid_puzzle(
+      "
+      // TODO #45 Привет, мир, мне кофе
+      //  вторая линия
+      ",
+      '2-3',
+      'Привет, мир, мне кофе вторая линия',
+      '45'
+    )
+  end
+
   def test_todo_colon_parsing
     check_valid_puzzle(
       "


### PR DESCRIPTION
## Description

Save puzzle content with UTF-8 encoding

<img width="460" alt="Screenshot 2021-09-06 at 08 31 24" src="https://user-images.githubusercontent.com/10655408/132180560-d3b15c85-25b3-42a7-b572-80387a47cd87.png">

<img width="380" alt="Screenshot 2021-09-06 at 08 30 53" src="https://user-images.githubusercontent.com/10655408/132180541-11129d60-2848-450d-90b1-fea7d0ec19c5.png">

Also resolves #143

## Types of changes

- [ ] Documentation Update 📝
- [ ] Build/Workflow Update 👷
- [x] Updates/Feature
- [ ] Other (please describe)

## Checklist

- [x] Lint and tests pass locally with my changes
- [x] Added documentation (if appropriate)

