### PR TITLE
[#163] Use blank lines instead of indentation as issue body markers

### DIFF
--- a/features/catches_broken_puzzles.feature
+++ b/features/catches_broken_puzzles.feature
@@ -20,21 +20,4 @@ Feature: Catches Broken Puzzles
       }
     }
     """
-    When I run pdd it fails with "Space expected"
     When I run pdd it fails with "Sample.java:6"
-
-  Scenario: Throwing exception on yet another broken puzzle
-    Given I have a "Sample.java" file with content:
-    """
-    public class Main {
-      //
-      // @todo #13 This puzzle has an incorrect format
-      // because there is no space character in the
-      // second and third lines
-      //
-      public void main(String[] args) {
-        // later
-      }
-    }
-    """
-    When I run pdd it fails with "Space expected"

--- a/features/catches_broken_puzzles.feature
+++ b/features/catches_broken_puzzles.feature
@@ -11,9 +11,8 @@ Feature: Catches Broken Puzzles
        * Some other documentation
        * text that is not relevant to
        * the puzzle below.
-       * @todo #13 This puzzle has an incorrect format
-       * because it doesn't start with a space on
-       * the second and the third lines
+       * @todo This puzzle has an incorrect format
+       * because it doesn't have a ticket number
        */
       public void main(String[] args) {
         // later

--- a/features/parsing.feature
+++ b/features/parsing.feature
@@ -25,6 +25,32 @@ Feature: Parsing
     And XML matches "//puzzle[role='DEV']"
     And XML matches "//puzzle[estimate='0']"
 
+  Scenario: Simple puzzle within comment block
+    Given I have a "test/a/b/Sample.java" file with content:
+    """
+    public class Main {
+      /**
+       * Some other documentation
+       * text that is not relevant to
+       * the puzzle below.
+       * @todo #13 This puzzle has a correct format
+       * It doesn't start with a space on
+       * the second and the third lines
+       */
+      public void main(String[] args) {
+        // later
+      }
+    }
+    """
+    When I run pdd
+    Then XML matches "/puzzles[count(puzzle)=1]"
+    And XML matches "//puzzle[file='test/a/b/Sample.java']"
+    And XML matches "//puzzle[ticket='13']"
+    And XML matches "//puzzle[lines='6-8']"
+    And XML matches "//puzzle[starts-with(body,'This')]"
+    And XML matches "//puzzle[role='DEV']"
+    And XML matches "//puzzle[estimate='0']"
+
   Scenario: Multiple puzzles in one file
     Given I have a "test/a/b/c/Sample.java" file with content:
     """
@@ -44,7 +70,7 @@ Feature: Parsing
     }
     """
     When I run pdd
-    Then XML matches "/puzzles[count(puzzle)=3]"
+    Then XML matches "/puzzles[count(puzzle)=4]"
     And XML matches "//puzzle[ticket='13' and lines='3-3']"
     And XML matches "//puzzle[ticket='13' and body='This one later']"
     And XML matches "//puzzle[ticket='ABC-67' and lines='4-4']"

--- a/features/parsing.feature
+++ b/features/parsing.feature
@@ -34,6 +34,9 @@ Feature: Parsing
        * @todo #ABC-67:15min And this one ever later
        * @todo #F-78-3:2h/DEV This is for a developer
        *  who will join us later
+       * @todo #44 This puzzle has a correct format
+       * even though it doesn't start with a space on
+       * the second and the third lines
        */
       public void main(String[] args) {
         // later
@@ -48,3 +51,4 @@ Feature: Parsing
     And XML matches "//puzzle[ticket='F-78-3' and lines='5-6']"
     And XML matches "//puzzle[ticket='ABC-67' and estimate='15']"
     And XML matches "//puzzle[ticket='F-78-3' and estimate='120']"
+    And XML matches "//puzzle[ticket='44' and lines='7-9']"

--- a/lib/pdd/source.rb
+++ b/lib/pdd/source.rb
@@ -105,7 +105,7 @@ see https://github.com/cqfn/pdd#how-to-format"
 
     # Fetch puzzle
     def puzzle(lines, match, idx)
-      tail = tail(lines, match[1], idx)
+      tail = tail(lines, match[1])
       body = "#{match[3]} #{tail.join(' ')}".gsub(/\s+/, ' ').strip
       body = body.chomp('*/-->').strip
       marker = marker(match[2])
@@ -142,18 +142,17 @@ against the rules explained here: https://github.com/cqfn/pdd#how-to-format"
     end
 
     # Fetch puzzle tail (all lines after the first one)
-    def tail(lines, prefix, start)
+    def tail(lines, prefix)
+      prefix = prefix.rstrip
       lines
         .take_while { |t| match_markers(t).none? && t.start_with?(prefix) }
+        .take_while do |t|
+          # account for carriage return in line endings
+          t_len = t.length - 1
+          t_len <= prefix.length || t_len > prefix.length + 2
+        end
         .map { |t| t[prefix.length, t.length] }
-        .take_while { |t| t =~ /^[ a-zA-Z0-9]/ }
-        .each_with_index do |t, i|
-        next if t.start_with?(' ')
-
-        raise Error, "Space expected at #{start + i + 2}:#{prefix.length}; \
-make sure all lines in the puzzle body have a single leading space."
-      end
-        .map { |t| t[1, t.length] }
+        .map { |t| t.start_with?(' ') ? t[1, t.length] : t }
     end
 
     # @todo #75:30min Let's make it possible to fetch Subversion data

--- a/test/test_source.rb
+++ b/test/test_source.rb
@@ -79,6 +79,31 @@ class TestSource < Minitest::Test
     end
   end
 
+  def test_multiple_puzzles_single_comment_block
+    Dir.mktmpdir 'test' do |dir|
+      file = File.join(dir, 'a.txt')
+      File.write(
+        file,
+        "
+        /*
+         * \x40todo #1 First one with
+         * a few lines
+         * \x40todo #1 Second one also
+         * with a few lines
+         */
+        "
+      )
+      stub_source_find_github_user(file, 'hey') do |source|
+        PDD.opts = nil
+        assert_equal 2, source.puzzles.size
+        puzzle = source.puzzles.last
+        assert_equal '5-6', puzzle.props[:lines]
+        assert_equal 'Second one also with a few lines', puzzle.props[:body]
+        assert_equal '1', puzzle.props[:ticket]
+      end
+    end
+  end
+
   def test_succeed_despite_bad_puzzles
     Dir.mktmpdir 'test' do |dir|
       file = File.join(dir, 'a.txt')

--- a/test/test_source.rb
+++ b/test/test_source.rb
@@ -46,8 +46,9 @@ class TestSource < Minitest::Test
         list = source.puzzles
         assert_equal 2, list.size
         puzzle = list.first
-        assert_equal '2-3', puzzle.props[:lines]
-        assert_equal 'привет, how are you doing?', puzzle.props[:body]
+        assert_equal '2-4', puzzle.props[:lines]
+        assert_equal 'привет, how are you doing? -something else', \
+                     puzzle.props[:body]
         assert_equal '44', puzzle.props[:ticket]
         assert puzzle.props[:author].nil?
         assert puzzle.props[:email].nil?
@@ -78,33 +79,16 @@ class TestSource < Minitest::Test
     end
   end
 
-  def test_failing_on_invalid_puzzle
-    Dir.mktmpdir 'test' do |dir|
-      file = File.join(dir, 'a.txt')
-      File.write(
-        file,
-        "
-        * \x40todo #44 this is an incorrectly formatted puzzle,
-        * with a second line without a leading space
-        "
-      )
-      error = assert_raises PDD::Error do
-        stub_source_find_github_user(file, 'hey', &:puzzles)
-      end
-      assert !error.message.index('Space expected').nil?
-    end
-  end
-
   def test_succeed_despite_bad_puzzles
     Dir.mktmpdir 'test' do |dir|
       file = File.join(dir, 'a.txt')
       File.write(
         file,
         "
-        * \x40todo #44 this is an incorrectly formatted puzzle,
+        * \x40todo #44 this is a correctly formatted puzzle,
         * with a second line without a leading space
         Another badly formatted puzzle
-        * \x40todo this puzzle misses ticket name/number
+        * \x40todo this bad puzzle misses ticket name/number
         Something else
         * \x40todo #123 This puzzle is correctly formatted
         "
@@ -113,11 +97,12 @@ class TestSource < Minitest::Test
       stub_source_find_github_user(file, 'hey') do |source|
         list = source.puzzles
         PDD.opts = nil
-        assert_equal 1, list.size
+        assert_equal 2, list.size
         puzzle = list.first
-        assert_equal '7-7', puzzle.props[:lines]
-        assert_equal 'This puzzle is correctly formatted', puzzle.props[:body]
-        assert_equal '123', puzzle.props[:ticket]
+        assert_equal '2-3', puzzle.props[:lines]
+        assert_equal 'this is a correctly formatted puzzle, with a second ' \
+                     'line without a leading space', puzzle.props[:body]
+        assert_equal '44', puzzle.props[:ticket]
       end
     end
   end

--- a/test/test_source_todo.rb
+++ b/test/test_source_todo.rb
@@ -121,24 +121,6 @@ class TestSourceTodo < Minitest::Test
     )
   end
 
-  def test_todo_failing_no_space_on_second_line
-    check_invalid_puzzle(
-      "
-      * TODO #45 this puzzle
-      * has not space on second line",
-      'Space expected'
-    )
-  end
-
-  def test_todo_colon_failing_no_space_on_second_line
-    check_invalid_puzzle(
-      "
-      * TODO: #45 this puzzle
-      * has not space on second line",
-      'Space expected'
-    )
-  end
-
   def test_todo_failing_no_ticket
     check_invalid_puzzle(
       "


### PR DESCRIPTION
Example:

Here's an example puzzle

```
# TODO: #1 Issue title
#
# ^ if you need an empty line for aesthetics
#
# Everything here is added as
# an issue body
#
# ... still the issue body

# This comment is left in the code (not part of puzzle body)
def greeting:
  print('Hello')
```