### PR TITLE
[108] eliminate tests skipping on windows

### DIFF
--- a/test/test_pdd.rb
+++ b/test/test_pdd.rb
@@ -57,7 +57,6 @@ class TestPDD < Minitest::Test
   end
 
   def test_git_repo
-    skip if Gem.win_platform?
     Dir.mktmpdir 'test' do |dir|
       opts = opts(['-q', '-s', dir])
       raise unless system("

--- a/test/test_pdd.rb
+++ b/test/test_pdd.rb
@@ -60,7 +60,6 @@ class TestPDD < Minitest::Test
     Dir.mktmpdir 'test' do |dir|
       opts = opts(['-q', '-s', dir])
       raise unless system("
-        set -e
         cd '#{dir}'
         git init --quiet .
         git config user.email test@teamed.io

--- a/test/test_source.rb
+++ b/test/test_source.rb
@@ -226,7 +226,6 @@ class TestSource < Minitest::Test
   end
 
   def test_reads_git_author
-    skip if Gem.win_platform?
     Dir.mktmpdir 'test' do |dir|
       raise unless system("
         set -e
@@ -255,7 +254,6 @@ class TestSource < Minitest::Test
   end
 
   def test_skips_invalid_git_mail
-    skip if Gem.win_platform?
     Dir.mktmpdir 'test' do |dir|
       raise unless system("
         set -e
@@ -284,7 +282,6 @@ class TestSource < Minitest::Test
   end
 
   def test_uses_github_login
-    skip if Gem.win_platform?
     Dir.mktmpdir 'test' do |dir|
       raise unless system("
         cd '#{dir}'
@@ -306,7 +303,6 @@ class TestSource < Minitest::Test
   end
 
   def test_skips_uncommitted_changes
-    skip if Gem.win_platform?
     Dir.mktmpdir 'test' do |dir|
       raise unless system("
         cd '#{dir}'


### PR DESCRIPTION
Case is the following:
``` 
There are several tests ignored on windows, e.g. test_reads_git_author. These tests are ignored via "skip if Gem.win_platform?" but this makes it very difficult to develop, since you can not run the entire test suite.
Imho these tests should not be ignored and should be fixed.
```

 May notice that there are not much strong differences in the commands for the terminal and Windows console; so we can correct this situation