### PR TITLE
[#207] fix wrongly detected puzzle body

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,13 +1,13 @@
 AllCops:
   Exclude:
-    - 'assets/**/*'
+    - "assets/**/*"
   DisplayCopNames: true
   TargetRubyVersion: 2.3
 
 Layout/EndOfLine:
   EnforcedStyle: lf
 Metrics/ClassLength:
-  Max: 300
+  Max: 360
 Metrics/LineLength:
   Max: 90
 Metrics/MethodLength:

--- a/lib/pdd/source.rb
+++ b/lib/pdd/source.rb
@@ -104,7 +104,8 @@ see https://github.com/cqfn/pdd#how-to-format"
 
     # Fetch puzzle
     def puzzle(lines, match, idx)
-      tail = tail(lines, match[1])
+      col_idx = match[0].length - match[0].lstrip.length
+      tail = tail(lines, match[1], col_idx)
       body = "#{match[3]} #{tail.join(' ')}".gsub(/\s+/, ' ').strip
       body = body.chomp('*/-->').strip
       marker = marker(match[2])
@@ -141,8 +142,9 @@ against the rules explained here: https://github.com/cqfn/pdd#how-to-format"
     end
 
     # Fetch puzzle tail (all lines after the first one)
-    def tail(lines, prefix)
+    def tail(lines, prefix, start)
       prefix = prefix.rstrip
+      prefix = " #{' ' * start}" if prefix.empty? # fallback to space indentation
       lines
         .take_while { |t| match_markers(t).none? && t.start_with?(prefix) }
         .take_while do |t|

--- a/test/test_source.rb
+++ b/test/test_source.rb
@@ -79,6 +79,30 @@ class TestSource < Minitest::Test
     end
   end
 
+  def test_no_prefix_multiline_puzzle_block
+    Dir.mktmpdir 'test' do |dir|
+      file = File.join(dir, 'a.txt')
+      File.write(
+        file,
+        "
+        <!--
+        \x40todo #01:30min correctly formatted multi-line puzzle, with no
+          comment prefix before todo marker
+        -->
+        "
+      )
+      stub_source_find_github_user(file, 'hey') do |source|
+        PDD.opts = nil
+        assert_equal 1, source.puzzles.size
+        puzzle = source.puzzles.last
+        assert_equal '3-4', puzzle.props[:lines]
+        assert_equal 'correctly formatted multi-line puzzle, with no ' \
+                     'comment prefix before todo marker', puzzle.props[:body]
+        assert_equal '01', puzzle.props[:ticket]
+      end
+    end
+  end
+
   def test_multiple_puzzles_single_comment_block
     Dir.mktmpdir 'test' do |dir|
       file = File.join(dir, 'a.txt')


### PR DESCRIPTION
- use spaces as indentation for puzzle body when no line comment prefix is found